### PR TITLE
xPlat support

### DIFF
--- a/DSCPullServerAdmin/DSCPullServerAdmin.psd1
+++ b/DSCPullServerAdmin/DSCPullServerAdmin.psd1
@@ -54,7 +54,7 @@ PowerShellVersion = '5.1'
 # RequiredModules = @()
 
 # Assemblies that must be loaded prior to importing this module
-RequiredAssemblies = @('Microsoft.Isam.Esent.Interop')
+# RequiredAssemblies = @()
 
 # Script files (.ps1) that are run in the caller's environment prior to importing this module.
 # ScriptsToProcess = @()
@@ -126,11 +126,12 @@ PrivateData = @{
         # IconUri = ''
 
         # ReleaseNotes of this module
-        ReleaseNotes = '* MDB Support
-* Bug fixes
-* Added wildcard attribute to parameters that support it (MDB does not support wildcards)
-* Added single char ? wildcard support besides *
-* Locked to PSv5.1+'
+        ReleaseNotes = 'Cross Platform support (Only SQL is supported xPlat. MDB and ESE are not)
+* Removed Microsoft.Isam.Esent.Interop from RequiredAssemblies
+* Load Microsoft.Isam.Esent.Interop when available
+* removed RetrieveColumnAsGuid and moved properties to RetrieveColumnAsString as something broke on latest w10 insiders
+
+* Fix ad-hoc mdb database access did not process as PreProc was missing MDB logic'
 
     } # End of PSData hashtable
 

--- a/DSCPullServerAdmin/DSCPullServerAdmin.psm1
+++ b/DSCPullServerAdmin/DSCPullServerAdmin.psm1
@@ -23,7 +23,6 @@ $private = Get-ChildItem -Path $PSScriptRoot\Private\*.ps1 -Exclude WIP* -ErrorA
 }
 
 $moduleContent = @'
-Add-Type -Path 'C:\Windows\Microsoft.NET\assembly\GAC_MSIL\microsoft.isam.esent.interop\*\Microsoft.Isam.Esent.Interop.dll'
 $DSCPullServerConnections = [System.Collections.ArrayList]::new()
 {0}
 {1}

--- a/DSCPullServerAdmin/private/Assert-DSCPullServerESEPreReq.ps1
+++ b/DSCPullServerAdmin/private/Assert-DSCPullServerESEPreReq.ps1
@@ -1,0 +1,11 @@
+function Assert-DSCPullServerESEPreReq {
+    # see if type is already available, don't load when already loaded
+    if ($null -eq ('Microsoft.Isam.Esent.Interop.Api'-as [type])) {
+        # try to load
+        try {
+            [void][System.Reflection.Assembly]::LoadWithPartialName('Microsoft.Isam.Esent.Interop')
+        } catch {
+            Write-Error -Message 'To access EDB files, please use PowerShell on Windows' -ErrorAction Stop
+        }
+    }
+}

--- a/DSCPullServerAdmin/private/Get-DSCPullServerESERecord.ps1
+++ b/DSCPullServerAdmin/private/Get-DSCPullServerESERecord.ps1
@@ -51,7 +51,10 @@ function Get-DSCPullServerESERecord {
             'LCMVersion',
             'ReportFormatVersion',
             'ConfigurationVersion',
-            'RebootRequested'
+            'RebootRequested',
+            'JobId',
+            'Id',
+            'ConfigurationID'
         )
 
         $boolColumns = @(
@@ -65,12 +68,6 @@ function Get-DSCPullServerESERecord {
             'StartTime',
             'EndTime',
             'LastModifiedTime'
-        )
-
-        $guidColumns = @(
-            'JobId',
-            'Id',
-            'ConfigurationID'
         )
 
         $deserializeColumns = @(
@@ -137,12 +134,6 @@ function Get-DSCPullServerESERecord {
                         )
                     } elseif ($column.Name -in $boolColumns) {
                         $result."$($column.Name)" = [Microsoft.Isam.Esent.Interop.Api]::RetrieveColumnAsBoolean(
-                            $Connection.SessionId,
-                            $Connection.TableId,
-                            $column.Columnid
-                        )
-                    } elseif ($column.Name -in $guidColumns) {
-                        $result."$($column.Name)" = [Microsoft.Isam.Esent.Interop.Api]::RetrieveColumnAsGuid(
                             $Connection.SessionId,
                             $Connection.TableId,
                             $column.Columnid

--- a/DSCPullServerAdmin/private/PreProc.ps1
+++ b/DSCPullServerAdmin/private/PreProc.ps1
@@ -13,6 +13,8 @@ function PreProc {
 
         [string] $ESEFilePath,
 
+        [string] $MDBFilePath,
+
         [Parameter(ValueFromRemainingArguments)]
         $DroppedParams
     )
@@ -42,6 +44,13 @@ function PreProc {
                 DontStore = $true
             }
             New-DSCPullServerAdminConnection @newESEArgs
+        }
+        *MDB {
+            $newMDBArgs = @{
+                MDBFilePath = $MDBFilePath
+                DontStore = $true
+            }
+            New-DSCPullServerAdminConnection @newMDBArgs
         }
     }
 }

--- a/DSCPullServerAdmin/public/New-DSCPullServerAdminConnection.ps1
+++ b/DSCPullServerAdmin/public/New-DSCPullServerAdminConnection.ps1
@@ -70,6 +70,10 @@ function New-DSCPullServerAdminConnection {
         Assert-DSCPullServerMDBPreReq
     }
 
+    if ($PSCmdlet.ParameterSetName -eq 'ESE') {
+        Assert-DSCPullServerESEPreReq
+    }
+
     $currentConnections = Get-DSCPullServerAdminConnection
     $lastIndex = $currentConnections |
         Sort-Object -Property Index -Descending |

--- a/DSCPullServerAdmin/tests/Unit/public/New-DSCPullServerAdminConnection.tests.ps1
+++ b/DSCPullServerAdmin/tests/Unit/public/New-DSCPullServerAdminConnection.tests.ps1
@@ -17,15 +17,18 @@ InModuleScope $moduleName {
             Mock -CommandName Test-DSCPullServerDatabase -MockWith {
                 $true
             }
+            Mock -CommandName Assert-DSCPullServerESEPreReq
 
             $null = New-Item -Path TestDrive: -Name pull.edb -ItemType File -Force
             $result = New-DSCPullServerAdminConnection -ESEFilePath $tempEDBFile.FullName
             $result.Index | Should -Be 0
             $result.Type | SHould -Be 'ESE'
             $script:DSCPullServerConnections | Should -Not -BeNullOrEmpty
+
+            Assert-MockCalled -CommandName Assert-DSCPullServerESEPreReq -Times 1 -Exactly -Scope it
         }
 
-        It 'Should assign index 1 when previous connecions are in module var DSCPullServerConnections' {
+        It 'Should assign index 1 when previous connections are in module var DSCPullServerConnections' {
             Mock -CommandName Get-DSCPullServerAdminConnection -MockWith {
                 $sqlConnection = [DSCPullServerSQLConnection]::new()
                 $sqlConnection.Active = $true
@@ -36,6 +39,8 @@ InModuleScope $moduleName {
             Mock -CommandName Test-DSCPullServerDatabase -MockWith {
                 $true
             }
+
+            Mock -CommandName Assert-DSCPullServerESEPreReq
 
             $result = New-DSCPullServerAdminConnection -ESEFilePath $tempEDBFile.FullName
             $result.Index | Should -Be 1
@@ -48,9 +53,12 @@ InModuleScope $moduleName {
             Mock -CommandName Test-DSCPullServerDatabase -MockWith {
                 $true
             }
+            Mock -CommandName Assert-DSCPullServerMDBPreReq
 
-            $null = New-DSCPullServerAdminConnection -ESEFilePath $tempEDBFile.FullName -DontStore
+            $null = New-DSCPullServerAdminConnection -MDBFilePath $tempMDBFile.FullName -DontStore
             $script:DSCPullServerConnections | Should -BeNullOrEmpty
+
+            Assert-MockCalled -CommandName Assert-DSCPullServerMDBPreReq -Times 1 -Exactly -Scope it
         }
 
         It 'Should create a SQL Connection when no Credentials are specified and database is specified and connection is validated true' {
@@ -64,6 +72,9 @@ InModuleScope $moduleName {
                 $true
             }
 
+            Mock -CommandName Assert-DSCPullServerESEPreReq
+            Mock -CommandName Assert-DSCPullServerMDBPreReq
+
             $result = New-DSCPullServerAdminConnection -SQLServer 'Server\Instance' -Database 'DSCDB'
             $result.Index | Should -Be 0
             $result.Type | Should -Be 'SQL'
@@ -71,6 +82,9 @@ InModuleScope $moduleName {
             $result.Credential | Should -BeNullOrEmpty
             $result.Database | Should -Be 'DSCDB'
             $script:DSCPullServerConnections | Should -Not -BeNullOrEmpty
+
+            Assert-MockCalled -CommandName Assert-DSCPullServerESEPreReq -Times 0 -Exactly -Scope it
+            Assert-MockCalled -CommandName Assert-DSCPullServerMDBPreReq -Times 0 -Exactly -Scope it
         }
 
         It 'Should create a SQL Connection when Credential is specified and database is specified and connection is validated true' {


### PR DESCRIPTION
Cross Platform support (Only SQL is supported xPlat. MDB and ESE are not)
* Removed Microsoft.Isam.Esent.Interop from RequiredAssemblies
* Load Microsoft.Isam.Esent.Interop when available
* removed RetrieveColumnAsGuid and moved properties to RetrieveColumnAsString as something broke on latest w10 insiders

* Fix ad-hoc mdb database access did not process as PreProc was missing MDB logic

Fixes: #45 