### PR TITLE
Fix for 'too many tables open' issue on edb

### DIFF
--- a/DSCPullServerAdmin/private/Get-DSCPullServerESERecord.ps1
+++ b/DSCPullServerAdmin/private/Get-DSCPullServerESERecord.ps1
@@ -67,9 +67,15 @@ function Get-DSCPullServerESERecord {
             'StatusCode'
         )
 
+        $actualColumns = @()
+
         try {
             Mount-DSCPullServerESEDatabase -Connection $Connection -Mode None
             Open-DSCPullServerTable -Connection $Connection -Table $Table
+            # Preload table columns to avoid the 'too many tables open' issue.
+            foreach ($column in ([Microsoft.Isam.Esent.Interop.Api]::GetTableColumns($Connection.SessionId, $Connection.TableId))) {
+                $actualColumns += $column
+            }
         } catch {
             Write-Error -ErrorRecord $_ -ErrorAction Stop
         }

--- a/DSCPullServerAdmin/private/Get-DSCPullServerESERecord.ps1
+++ b/DSCPullServerAdmin/private/Get-DSCPullServerESERecord.ps1
@@ -102,7 +102,7 @@ function Get-DSCPullServerESERecord {
                         $result = [DSCNodeStatusReport]::new()
                     }
                 }
-                foreach ($column in ([Microsoft.Isam.Esent.Interop.Api]::GetTableColumns($Connection.SessionId, $Connection.TableId))) {
+                foreach ($column in $actualColumns) {
                     if ($column.Name -eq 'IPAddress') {
                         $ipAddress = ([Microsoft.Isam.Esent.Interop.Api]::RetrieveColumnAsString(
                                 $Connection.SessionId,


### PR DESCRIPTION
Hi @bgelens,
I may have found a way to fix the "Cannot open any more tables" error for edb files with too many entries (see #58). I admit it is not based on an actual investigation looking for the root cause, but empirical testing.

What I did was basically modify the Get-DSCPullServerESERecord to prevent a lookup of table columns for every entry:
- Move `GetTableColumns` to the 'begin' phase, saving the columns in an array
- Use such array in the 'process' phase, when for each entry the code loads the entry's values

Apparently this solves the immediate issue. I have no idea why this would make a change since, as I said, I haven't figured out the root cause, so there may be unintended side effects. I did a few practical tests and everything seems to be working. If you can run a few tests yourself it would be much appreciated!